### PR TITLE
[#37] 회원 정보 수정 페이지

### DIFF
--- a/app/(tabs)/myPage/changePassword.tsx
+++ b/app/(tabs)/myPage/changePassword.tsx
@@ -22,6 +22,7 @@ export default function ChangePassword() {
   const [apiError, setApiError] = useState("");
   const isNewPasswordValid = newPassword.length >= 8;
   const isPasswordMatch = newPassword === confirmPassword && confirmPassword.length > 0;
+  const isFormValid = currentPassword.length > 0 && isNewPasswordValid && isPasswordMatch;
 
   const handleChangePassword = async () => {
     // 에러 초기화
@@ -61,6 +62,9 @@ export default function ChangePassword() {
         newPassword,
         newPasswordConfirm: confirmPassword,
       });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
       router.back();
     } catch (error: any) {
       const message = error.response?.data?.message || "비밀번호 변경에 실패했습니다.";
@@ -134,7 +138,7 @@ export default function ChangePassword() {
         <Button
           text={isLoading ? "변경 중..." : "비밀번호 변경"}
           onPress={handleChangePassword}
-          disabled={isLoading}
+          disabled={isLoading || !isFormValid}
         />
       </BottomSection>
     </Container>

--- a/app/(tabs)/myPage/changePassword.tsx
+++ b/app/(tabs)/myPage/changePassword.tsx
@@ -1,7 +1,4 @@
-// @/app/myPage/changePassword.tsx
 import { useState } from "react";
-
-import { Alert } from "react-native";
 
 import { useRouter } from "expo-router";
 import styled from "styled-components/native";
@@ -19,36 +16,55 @@ export default function ChangePassword() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [currentPasswordError, setCurrentPasswordError] = useState("");
+  const [newPasswordError, setNewPasswordError] = useState("");
+  const [confirmPasswordError, setConfirmPasswordError] = useState("");
+  const [apiError, setApiError] = useState("");
+  const isNewPasswordValid = newPassword.length >= 8;
+  const isPasswordMatch = newPassword === confirmPassword && confirmPassword.length > 0;
 
   const handleChangePassword = async () => {
-    // 유효성 검사
-    if (!currentPassword || !newPassword || !confirmPassword) {
-      Alert.alert("오류", "모든 필드를 입력해주세요.");
-      return;
+    // 에러 초기화
+    setCurrentPasswordError("");
+    setNewPasswordError("");
+    setConfirmPasswordError("");
+    setApiError("");
+
+    let hasError = false;
+
+    if (!currentPassword) {
+      setCurrentPasswordError("현재 비밀번호를 입력해주세요.");
+      hasError = true;
     }
 
-    if (newPassword !== confirmPassword) {
-      Alert.alert("오류", "새 비밀번호가 일치하지 않습니다.");
-      return;
+    if (!newPassword) {
+      setNewPasswordError("새 비밀번호를 입력해주세요.");
+      hasError = true;
+    } else if (newPassword.length < 8) {
+      setNewPasswordError("비밀번호는 8자 이상이어야 합니다.");
+      hasError = true;
     }
 
-    if (newPassword.length < 8) {
-      Alert.alert("오류", "비밀번호는 8자 이상이어야 합니다.");
-      return;
+    if (!confirmPassword) {
+      setConfirmPasswordError("비밀번호 확인을 입력해주세요.");
+      hasError = true;
+    } else if (newPassword !== confirmPassword) {
+      setConfirmPasswordError("새 비밀번호가 일치하지 않습니다.");
+      hasError = true;
     }
+
+    if (hasError) return;
 
     try {
       await updatePassword({
         currentPassword,
         newPassword,
+        newPasswordConfirm: confirmPassword,
       });
-      Alert.alert("성공", "비밀번호가 변경되었습니다.", [
-        { text: "확인", onPress: () => router.back() },
-      ]);
+      router.back();
     } catch (error: any) {
-      const message =
-        error.response?.data?.message || "비밀번호 변경에 실패했습니다.";
-      Alert.alert("오류", message);
+      const message = error.response?.data?.message || "비밀번호 변경에 실패했습니다.";
+      setApiError(message);
     }
   };
 
@@ -56,35 +72,62 @@ export default function ChangePassword() {
     <Container>
       <Content>
         <GuideText>새로운 비밀번호를 설정해주세요.</GuideText>
+
         <InputSection>
           <Label>현재 비밀번호 입력</Label>
           <StyledInput
             value={currentPassword}
-            onChangeText={setCurrentPassword}
+            onChangeText={(text) => {
+              setCurrentPassword(text);
+              setCurrentPasswordError("");
+              setApiError("");
+            }}
             secureTextEntry
             placeholder="현재 비밀번호"
+            placeholderTextColor={theme.colors.text.textTertiary}
           />
+          {currentPasswordError && <ErrorText>{currentPasswordError}</ErrorText>}
         </InputSection>
 
         <InputSection>
           <Label>비밀번호 입력</Label>
           <StyledInput
             value={newPassword}
-            onChangeText={setNewPassword}
+            onChangeText={(text) => {
+              setNewPassword(text);
+              setNewPasswordError("");
+              setApiError("");
+            }}
             secureTextEntry
             placeholder="새 비밀번호 (8자 이상)"
+            placeholderTextColor={theme.colors.text.textTertiary}
           />
+          {newPasswordError && <ErrorText>{newPasswordError}</ErrorText>}
+          {newPassword.length > 0 && newPassword.length < 8 && !newPasswordError && (
+            <ErrorText>비밀번호는 최소 8자 이상이어야 합니다.</ErrorText>
+          )}
         </InputSection>
 
         <InputSection>
           <Label>비밀번호 확인</Label>
           <StyledInput
             value={confirmPassword}
-            onChangeText={setConfirmPassword}
+            onChangeText={(text) => {
+              setConfirmPassword(text);
+              setConfirmPasswordError("");
+              setApiError("");
+            }}
             secureTextEntry
             placeholder="새 비밀번호 확인"
+            placeholderTextColor={theme.colors.text.textTertiary}
           />
+          {confirmPasswordError && <ErrorText>{confirmPasswordError}</ErrorText>}
+          {confirmPassword.length > 0 && !isPasswordMatch && !confirmPasswordError && (
+            <ErrorText>비밀번호가 일치하지 않습니다.</ErrorText>
+          )}
         </InputSection>
+
+        {apiError && <ApiErrorText>{apiError}</ApiErrorText>}
       </Content>
 
       <BottomSection>
@@ -98,6 +141,20 @@ export default function ChangePassword() {
   );
 }
 
+const ErrorText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.xs}px;
+  color: ${theme.colors.alarm.error};
+  margin-top: 5px;
+`;
+
+const ApiErrorText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${theme.colors.alarm.error};
+  margin-top: 15px;
+  text-align: center;
+`;
 const Container = styled.View`
   flex: 1;
   background-color: ${theme.colors.white};

--- a/app/(tabs)/myPage/editProfile.tsx
+++ b/app/(tabs)/myPage/editProfile.tsx
@@ -68,10 +68,10 @@ export default function EditProfile() {
               ) : (
                 <ProfileImage />
                 
-              )}
-              {profileImageError && <ErrorText>{profileImageError}</ErrorText>}
+              )} 
             </ProfileImageTouchable>
           </ProfileImageWrapper>
+          {profileImageError && <ErrorText>{profileImageError}</ErrorText>}
         </ProfileImageSection>
 
         <InputSection>

--- a/app/(tabs)/myPage/editProfile.tsx
+++ b/app/(tabs)/myPage/editProfile.tsx
@@ -1,121 +1,53 @@
-import { useState } from "react";
-
-import { Alert, Modal, Platform } from "react-native";
+import { ActivityIndicator, Modal, Platform } from "react-native";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Picker } from "@react-native-picker/picker";
-import * as ImagePicker from "expo-image-picker";
-import { useRouter } from "expo-router";
 import styled from "styled-components/native";
 
 import Button from "@/components/common/Button";
 
-import { Gender } from "@/types/auth";
+import { useEditProfile } from "@/hooks/useEditProfile";
 
 import { theme } from "@/styles/theme";
 import { NATIONALITIES } from "@/constants/nationalities";
 
-import { useAuthStore } from "@/store/useAuthStore";
-
 export default function EditProfile() {
-  const router = useRouter();
-  const { user, updateProfile, updateProfileImage, isLoading } = useAuthStore();
-  const [nickname, setNickname] = useState(user?.nickname || "");
-  const [nationality, setNationality] = useState(
-    user?.nationality ?? "대한민국",
-  );
-  const [gender, setGender] = useState<"MALE" | "FEMALE">(
-    user?.gender ?? "MALE",
-  );
-  const [birthYear, setBirthYear] = useState("2000");
-  const [birthMonth, setBirthMonth] = useState("01");
-  const [birthDay, setBirthDay] = useState("01");
-  const [showNationalityPicker, setShowNationalityPicker] = useState(false);
-  const [showDatePicker, setShowDatePicker] = useState(false);
-  const [selectedDate, setSelectedDate] = useState(new Date(2000, 0, 1));
-  const [profileImageUri, setProfileImageUri] = useState<string | null>(
-    user?.profileImage ?? null,
-  );
+  const {
+    user,
+    isLoading,
+    isInitializing,
+    nickname,
+    setNickname,
+    nationality,
+    setNationality,
+    gender,
+    setGender,
+    birthYear,
+    birthMonth,
+    birthDay,
+    selectedDate,
+    profileImageUri,
+    showNationalityPicker,
+    setShowNationalityPicker,
+    showDatePicker,
+    setShowDatePicker,
+    handleDateChange,
+    handlePickImage,
+    handleSave,
+    handleOpenPasswordChange,
+    nicknameError,
+    setNicknameError,
+    profileImageError,
+    saveError,
+  } = useEditProfile();
 
-  const handleDateChange = (event: any, date?: Date) => {
-    if (date) {
-      setSelectedDate(date);
-      setBirthYear(date.getFullYear().toString());
-      setBirthMonth((date.getMonth() + 1).toString().padStart(2, "0"));
-      setBirthDay(date.getDate().toString().padStart(2, "0"));
-    }
-  };
-  const handlePickImage = async () => {
-    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!permission.granted) {
-      Alert.alert("권한 필요", "갤러리 접근 권한이 필요합니다.");
-      return;
-    }
-
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
-      allowsEditing: true,
-      aspect: [1, 1],
-      quality: 0.8,
-    });
-
-    if (!result.canceled && result.assets[0]) {
-      const asset = result.assets[0];
-      setProfileImageUri(asset.uri);
-
-      const formData = new FormData();
-      formData.append("file", {
-        uri: asset.uri,
-        type: "image/jpeg",
-        name: "profile.jpg",
-      } as any);
-
-      try {
-        await updateProfileImage(formData);
-        Alert.alert("성공", "프로필 사진이 변경되었습니다.");
-      } catch (error) {
-        Alert.alert("오류", "프로필 사진 업로드에 실패했습니다.");
-      }
-    }
-  };
-
-  const handleSave = async () => {
-    if (!nickname) {
-      Alert.alert("오류", "닉네임을 입력해주세요.");
-      return;
-    }
-
-    if (nickname.length < 2 || nickname.length > 50) {
-      Alert.alert("오류", "닉네임은 2자 이상 50자 이하여야 합니다.");
-      return;
-    }
-
-    const birthdate = `${birthYear}-${birthMonth.padStart(
-      2,
-      "0",
-    )}-${birthDay.padStart(2, "0")}`;
-
-    try {
-      await updateProfile({
-        nickname,
-        gender: gender === "MALE" ? Gender.MALE : Gender.FEMALE,
-        birthdate,
-        nationality,
-      });
-
-      Alert.alert("성공", "프로필이 수정되었습니다.", [
-        { text: "확인", onPress: () => router.back() },
-      ]);
-    } catch (error: any) {
-      const message =
-        error?.response?.data?.message || "프로필 수정에 실패했습니다.";
-      Alert.alert("오류", message);
-    }
-  };
-
-  const handleOpenPasswordChange = () => {
-    router.push("/myPage/changePassword");
-  };
+  if (isInitializing) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator size="large" color={theme.colors.main.primary} />
+      </LoadingContainer>
+    );
+  }
 
   return (
     <Container>
@@ -131,11 +63,13 @@ export default function EditProfile() {
             <ProfileImageTouchable onPress={handlePickImage}>
               {profileImageUri ? (
                 <ProfileImageActual
-                  source={{ uri: profileImageUri ?? user!.profileImage! }}
+                  source={{ uri: profileImageUri }}
                 />
               ) : (
                 <ProfileImage />
+                
               )}
+              {profileImageError && <ErrorText>{profileImageError}</ErrorText>}
             </ProfileImageTouchable>
           </ProfileImageWrapper>
         </ProfileImageSection>
@@ -150,10 +84,14 @@ export default function EditProfile() {
           <Label>닉네임</Label>
           <StyledInput
             value={nickname}
-            onChangeText={setNickname}
+            onChangeText={(text) => {
+              setNickname(text);
+              setNicknameError("");
+            }}
             placeholder="닉네임을 입력하세요"
             maxLength={50}
           />
+          {nicknameError && <ErrorText>{nicknameError}</ErrorText>}
         </InputSection>
 
         <InputSection>
@@ -202,6 +140,7 @@ export default function EditProfile() {
       </Content>
 
       <BottomSection>
+        {saveError && <ErrorText>{saveError}</ErrorText>}
         <Button
           text={isLoading ? "저장 중..." : "저장"}
           onPress={handleSave}
@@ -480,4 +419,18 @@ const ModalCloseText = styled.Text`
   font-family: ${theme.typography.fontFamily.medium};
   font-size: ${theme.typography.fontSize.md}px;
   color: ${theme.colors.main.primary};
+`;
+
+const LoadingContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.white};
+`;
+
+const ErrorText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.xs}px;
+  color: ${theme.colors.alarm.error};
+  margin-top: 5px;
 `;

--- a/app/(tabs)/myPage/forgotPassword.tsx
+++ b/app/(tabs)/myPage/forgotPassword.tsx
@@ -104,7 +104,8 @@ export default function ForgotPassword() {
     try {
       setIsLoading(true);
       await resetPasswordApi(email, newPassword);
-      router.replace("/myPage/login");
+      // router.replace("/myPage/login");
+      router.back();
     } catch (error) {
       if (error instanceof ApiError) {
         if (error.code === "MEM014") {

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -39,6 +39,7 @@ export const API_ENDPOINTS = {
     COMPLETE_ROUTE: (routeId: number) => `/api/user/route/${routeId}/complete`,
   },
   MEMBER: {
+    GET_PROFILE: "/api/user/member/profile",
     EDIT_PROFILE_IMAGE: "/api/user/member/profile-image",
     EDIT_PROFILE: "/api/user/member/profile",
     CHANGE_PASSWORD: "/api/user/member/password",

--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Alert } from "react-native";
+
+import * as ImagePicker from "expo-image-picker";
+import { useRouter } from "expo-router";
+
+import { Gender } from "@/types/auth";
+
+import { useAuthStore } from "@/store/useAuthStore";
+
+const parseBirthdate = (birthdate: number[] | string | null | undefined) => {
+    if (!birthdate) {
+        return { year: "2000", month: "01", day: "01", date: new Date(2000, 0, 1) };
+    }
+
+    if (Array.isArray(birthdate)) {
+        const [year, month, day] = birthdate;
+        return {
+            year: year.toString(),
+            month: month.toString().padStart(2, "0"),
+            day: day.toString().padStart(2, "0"),
+            date: new Date(year, month - 1, day),
+        };
+    }
+
+    // 문자열인 경우
+    const [year, month, day] = birthdate.split("-");
+    return {
+        year,
+        month,
+        day,
+        date: new Date(parseInt(year), parseInt(month) - 1, parseInt(day)),
+    };
+};
+
+export const useEditProfile = () => {
+    const router = useRouter();
+    const { user, updateProfile, updateProfileImage, fetchProfile, isLoading } = useAuthStore();
+
+    const [nickname, setNickname] = useState("");
+    const [nationality, setNationality] = useState("대한민국");
+    const [gender, setGender] = useState<"MALE" | "FEMALE">("MALE");
+    const [birthYear, setBirthYear] = useState("2000");
+    const [birthMonth, setBirthMonth] = useState("01");
+    const [birthDay, setBirthDay] = useState("01");
+    const [selectedDate, setSelectedDate] = useState(new Date(2000, 0, 1));
+    const [profileImageUri, setProfileImageUri] = useState<string | null>(null);
+
+    const [showNationalityPicker, setShowNationalityPicker] = useState(false);
+    const [showDatePicker, setShowDatePicker] = useState(false);
+    const [isInitializing, setIsInitializing] = useState(true);
+    const [nicknameError, setNicknameError] = useState("");
+    const [profileImageError, setProfileImageError] = useState("");
+    const [saveError, setSaveError] = useState("");
+
+    // 페이지 진입 시 서버에서 프로필 조회
+    useEffect(() => {
+        const initProfile = async () => {
+            try {
+                await fetchProfile();
+            } catch (error) {
+                console.error("프로필 조회 실패:", error);
+            } finally {
+                setIsInitializing(false);
+            }
+        };
+        initProfile();
+    }, []);
+
+    // user 업데이트 시 폼에 반영
+    useEffect(() => {
+        if (user && !isInitializing) {
+            setNickname(user.nickname || "");
+            setNationality(user.nationality || "대한민국");
+            setGender(user.gender || "MALE");
+            setProfileImageUri(user.profileImage || null);
+
+            const birth = parseBirthdate(user.birthdate);
+            setBirthYear(birth.year);
+            setBirthMonth(birth.month);
+            setBirthDay(birth.day);
+            setSelectedDate(birth.date);
+        }
+    }, [user, isInitializing]);
+
+    const handleDateChange = useCallback((event: any, date?: Date) => {
+        if (date) {
+            setSelectedDate(date);
+            setBirthYear(date.getFullYear().toString());
+            setBirthMonth((date.getMonth() + 1).toString().padStart(2, "0"));
+            setBirthDay(date.getDate().toString().padStart(2, "0"));
+        }
+    }, []);
+
+    const handlePickImage = useCallback(async () => {
+        setProfileImageError("");
+        const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+        if (!permission.granted) {
+            setProfileImageError("갤러리 접근 권한이 필요합니다.");
+            return;
+        }
+
+        const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ImagePicker.MediaTypeOptions.Images,
+            allowsEditing: true,
+            aspect: [1, 1],
+            quality: 0.8,
+        });
+
+        if (!result.canceled && result.assets[0]) {
+            const asset = result.assets[0];
+            const previousImageUri = profileImageUri;
+            setProfileImageUri(asset.uri);
+
+            const formData = new FormData();
+            formData.append("file", {
+                uri: asset.uri,
+                type: "image/jpeg",
+                name: "profile.jpg",
+            } as any);
+
+            try {
+                const newImageUrl = await updateProfileImage(formData);
+                setProfileImageUri(newImageUrl);
+            } catch (error) {
+                setProfileImageUri(previousImageUri);
+                setProfileImageError("프로필 사진 업로드에 실패했습니다.");
+            }
+        }
+    }, [updateProfileImage, profileImageUri]);
+
+    const handleSave = useCallback(async () => {
+        setNicknameError("");
+        setSaveError("");
+        if (!nickname) {
+            setNicknameError("닉네임을 입력해주세요.");
+            return;
+        }
+        if (nickname.length < 2 || nickname.length > 50) {
+            setNicknameError("닉네임은 2자 이상 50자 이하여야 합니다.");
+            return;
+        }
+
+        const birthdate = `${birthYear}-${birthMonth.padStart(2, "0")}-${birthDay.padStart(2, "0")}`;
+
+        try {
+            await updateProfile({
+                nickname,
+                gender: gender === "MALE" ? Gender.MALE : Gender.FEMALE,
+                birthdate,
+                nationality,
+            });
+            router.back();
+        } catch (error: any) {
+            const message = error?.response?.data?.message || "프로필 수정에 실패했습니다.";
+            setSaveError(message);
+        }
+    }, [nickname, gender, birthYear, birthMonth, birthDay, nationality, updateProfile, router]);
+
+    const handleOpenPasswordChange = useCallback(() => {
+        router.push("/myPage/changePassword");
+    }, [router]);
+
+    return {
+        user,
+        isLoading,
+        isInitializing,
+        nickname,
+        setNickname,
+        nationality,
+        setNationality,
+        gender,
+        setGender,
+        birthYear,
+        birthMonth,
+        birthDay,
+        selectedDate,
+        profileImageUri,
+        showNationalityPicker,
+        setShowNationalityPicker,
+        showDatePicker,
+        setShowDatePicker,
+        handleDateChange,
+        handlePickImage,
+        handleSave,
+        handleOpenPasswordChange,
+        nicknameError,
+        setNicknameError,
+        profileImageError,
+        saveError,
+    };
+};

--- a/src/hooks/useEditProfile.ts
+++ b/src/hooks/useEditProfile.ts
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { Alert } from "react-native";
-
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 
@@ -9,22 +7,11 @@ import { Gender } from "@/types/auth";
 
 import { useAuthStore } from "@/store/useAuthStore";
 
-const parseBirthdate = (birthdate: number[] | string | null | undefined) => {
+const parseBirthdate = (birthdate: string | null | undefined) => {
     if (!birthdate) {
         return { year: "2000", month: "01", day: "01", date: new Date(2000, 0, 1) };
     }
 
-    if (Array.isArray(birthdate)) {
-        const [year, month, day] = birthdate;
-        return {
-            year: year.toString(),
-            month: month.toString().padStart(2, "0"),
-            day: day.toString().padStart(2, "0"),
-            date: new Date(year, month - 1, day),
-        };
-    }
-
-    // 문자열인 경우
     const [year, month, day] = birthdate.split("-");
     return {
         year,

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -38,7 +38,7 @@ interface AuthState {
   socialSignup: (userData: SocialSignUpRequest) => Promise<void>;
   logout: () => Promise<void>;
   loadUser: () => Promise<void>;
-
+  fetchProfile: () => Promise<void>;
   updateProfile: (data: ProfileUpdateRequest) => Promise<ProfileUpdateResponse>;
   updateProfileImage: (file: FormData) => Promise<string>;
   updatePassword: (data: PasswordUpdateRequest) => Promise<void>;
@@ -78,6 +78,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         isLogined: true,
         isLoading: false,
       });
+      await get().fetchProfile();
     } catch (error) {
       set({
         user: null,
@@ -292,6 +293,38 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         data,
       );
       set({ isLoading: false });
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
+  },
+
+  fetchProfile: async () => {
+    try {
+      set({ isLoading: true });
+
+      const response = await api.get<BaseResponse<ProfileUpdateResponse>>(
+        API_ENDPOINTS.MEMBER.GET_PROFILE,
+      );
+
+      const profile = response.data.data;
+      const currentUser = get().user;
+
+      if (currentUser) {
+        const updatedUser: User = {
+          ...currentUser,
+          nickname: profile.nickname,
+          gender: profile.gender,
+          birthdate: profile.birthdate,
+          nationality: profile.nationality,
+          profileImage: profile.profileImage,
+        };
+
+        await SecureStore.setItemAsync(USER_INFO, JSON.stringify(updatedUser));
+        set({ user: updatedUser, isLoading: false });
+      } else {
+        set({ isLoading: false });
+      }
     } catch (error) {
       set({ isLoading: false });
       throw error;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -77,7 +77,7 @@ export interface User {
   profileUrl: string;
   profileImage?: string;
   gender?: Gender;
-  birthdate?: number[] | string;
+  birthdate?: string;
   nationality?: string;
 }
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -77,7 +77,7 @@ export interface User {
   profileUrl: string;
   profileImage?: string;
   gender?: Gender;
-  birthdate?: string;
+  birthdate?: number[] | string;
   nationality?: string;
 }
 

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -20,4 +20,5 @@ export interface ProfileUpdateResponse {
 export interface PasswordUpdateRequest {
   currentPassword: string;
   newPassword: string;
+  newPasswordConfirm: string;
 }


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 회원정보 수정 페이지 hook 분리
- 회원정보 수정 페이지 - 수정 시 업데이트 안되는 부분 해결 및 에러 메시지 인라인으로 변경
- 회원정보 수정 페이지 -> 비밀번호 변경 페이지 API 연결 및 에러 메시지 인라인으로 변경
- 로그인 시 프로필 사진 안보이는 이슈 수정
- 비밀번호 찾기를 통해 비밀번호 변경 시 로그인 페이지 뷰 중첩 이슈 수정

---

## 🧪 테스트 결과

https://github.com/user-attachments/assets/83c0486b-7aae-4fc8-ae3d-96aa26c0a7c8

https://github.com/user-attachments/assets/7c3185cc-f84e-48c2-948a-c62e4b5bf860

https://github.com/user-attachments/assets/e11fe0ff-7b58-4b81-adaa-5b4303eea427


---

## BREAKING CHANGE (옵션)

- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고

- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)
- 기존 작업된 editProfile.tsx 페이지에서 컴포넌트 조합 및 레이아웃만 남겨놓고 useEditProfile.ts 분리 , useAuthStore.ts 사용으로 변경했습니다
---

## 🪞 회고 및 개선 아이디어 (옵션)
- 다른 페이지 코드 디자인 패턴 개선은 계속 하겠습니다

---

## 💬 리뷰 받고 싶은 부분 (옵션)
- 디자인 패턴 hook 분리했는데 리뷰 부탁드립니다

