### PR TITLE
[#42] 마이페이지 - 내 이야기

### DIFF
--- a/app/(tabs)/myPage/index.tsx
+++ b/app/(tabs)/myPage/index.tsx
@@ -103,7 +103,7 @@ function LoggedInView({
       </ProfileSection>
 
       <TabArea>
-        <TabButton onPress={() => console.log("내 이야기")}>
+        <TabButton onPress={() => router.push("/myPage/myStory")}>
           <MyStoryIcon width={24} height={24} color={theme.colors.white} />
           <TabLabel>내 이야기</TabLabel>
         </TabButton>
@@ -241,6 +241,7 @@ const MenuItemText = styled.Text`
 const LogoutButton = styled.TouchableOpacity`
   padding: 20px;
   align-items: center;
+  align-self: center;
 `;
 
 const LogoutText = styled.Text`

--- a/app/(tabs)/myPage/myStory.tsx
+++ b/app/(tabs)/myPage/myStory.tsx
@@ -1,0 +1,219 @@
+import { useEffect,useRef, useState  } from "react";
+
+import { ActivityIndicator, FlatList } from "react-native";
+import PagerView from "react-native-pager-view";
+
+import styled from "styled-components/native";
+
+import StoryCard from "@/components/story/StoryCard";
+
+import { useLikedStory } from "@/hooks/story/useLikedStory";
+import { useMyStory } from "@/hooks/story/useMyStory";
+
+import { MyStoryItem } from "@/types/myStory";
+
+import { theme } from "@/styles/theme";
+
+import { useAuthStore } from "@/store/useAuthStore";
+
+type TabType = "myStory" | "liked";
+
+export default function MyStory() {
+  const pagerRef = useRef<PagerView>(null);
+  const [activeTab, setActiveTab] = useState<TabType>("myStory");
+  const myStories = useMyStory((s) => s.myStories);
+  const hasNext = useMyStory((s) => s.hasNext);
+  const isLoading = useMyStory((s) => s.isLoading);
+  const fetchMyStories = useMyStory((s) => s.fetchMyStories);
+
+  const likedStories = useLikedStory((s) => s.likedStories);
+  const likedHasNext = useLikedStory((s) => s.hasNext);
+  const likedIsLoading = useLikedStory((s) => s.isLoading);
+  const fetchLikedStories = useLikedStory((s) => s.fetchLikedStories);
+  const refreshLikedStories = useLikedStory((s) => s.refreshLikedStories);
+
+  useEffect(() => {
+    fetchMyStories(true);
+    fetchLikedStories(true);
+  }, []);
+
+    const handleTabPress = (tab: TabType) => {
+        setActiveTab(tab);
+        pagerRef.current?.setPage(tab === "myStory" ? 0 : 1);
+    };
+
+  const handlePageSelected = (e: { nativeEvent: { position: number } }) => {
+        const position = e.nativeEvent.position;
+        setActiveTab(position === 0 ? "myStory" : "liked");
+  };
+
+  const { user } = useAuthStore();
+
+  return (
+    <Container>
+      {/* 헤더 영역 */}
+      <HeaderPlaceholder />
+
+      <TabContainer>
+        <TabButton
+          active={activeTab === "myStory"}
+          onPress={() => handleTabPress("myStory")}
+        >
+          <TabText active={activeTab === "myStory"}>MY 이야기</TabText>
+        </TabButton>
+        <TabButton
+          active={activeTab === "liked"}
+          onPress={() => handleTabPress("liked")}
+        >
+          <TabText active={activeTab === "liked"}>내가 좋아요한 글</TabText>
+        </TabButton>
+      </TabContainer>
+
+      <StyledPagerView
+        ref={pagerRef}
+        initialPage={0}
+        onPageSelected={handlePageSelected}
+        >
+        <PageContainer key="1">
+            <FlatList
+                data={myStories}
+                style={{ flex: 1 }}
+                contentContainerStyle={{ flexGrow: 1 }}
+                keyExtractor={(item) => item.storyId.toString()}
+                refreshing={isLoading}
+                onRefresh={() => fetchMyStories(true)}
+                renderItem={({ item }) => (
+                <StoryCard
+                  storyId={item.storyId}
+                  authorId={user?.memberId}
+                  profileUrl={item.storyAuthor?.profileUrl || user?.profileImage}
+                  userNickName={item.storyAuthor?.nickname}
+                  stroySpotName={item.title}
+                  storyConcept={item.storyConcept}
+                  content={item.content}
+                  imageUrls={item.imageUrls}
+                  likeCount={item.likeCount}
+                  isLiked={item.isLiked}
+                  createdAt={item.createdAt as string}
+                />
+                )}
+                onEndReached={() => {
+                if (hasNext && !isLoading) {
+                    fetchMyStories(false);
+                }
+                }}
+                onEndReachedThreshold={0.5}
+                ListFooterComponent={
+                isLoading ? <ActivityIndicator style={{ padding: 20 }} /> : null
+                }
+                ListEmptyComponent={
+                !isLoading ? (
+                    <EmptyContainer>
+                    <EmptyText>작성한 이야기가 없습니다</EmptyText>
+                    </EmptyContainer>
+                ) : null
+                }
+            />
+            </PageContainer>
+            <PageContainer key="2">
+              <FlatList
+                data={likedStories}
+                style={{ flex: 1 }}
+                contentContainerStyle={{ flexGrow: 1 }}
+                keyExtractor={(item) => item.storyId.toString()}
+                refreshing={likedIsLoading}
+                onRefresh={refreshLikedStories}
+                renderItem={({ item }: { item: MyStoryItem }) => (
+                  <StoryCard
+                    storyId={item.storyId}
+                    authorId={user?.memberId}
+                    profileUrl={item.storyAuthor?.profileUrl}
+                    userNickName={item.storyAuthor?.nickname}
+                    stroySpotName={item.title}
+                    storyConcept={item.storyConcept}
+                    content={item.content}
+                    imageUrls={item.imageUrls}
+                    likeCount={item.likeCount}
+                    isLiked={item.isLiked}
+                    createdAt={item.createdAt as string}
+                  />
+                )}
+                onEndReached={() => {
+                  if (likedHasNext && !likedIsLoading) {
+                    fetchLikedStories(false);
+                  }
+                }}
+                onEndReachedThreshold={0.5}
+                ListFooterComponent={
+                  likedIsLoading ? <ActivityIndicator style={{ padding: 20 }} /> : null
+                }
+                ListEmptyComponent={
+                  !likedIsLoading ? (
+                    <EmptyContainer>
+                      <EmptyText>좋아요한 글이 없습니다</EmptyText>
+                    </EmptyContainer>
+                  ) : null
+                }
+              />
+            </PageContainer>
+        </StyledPagerView>
+    </Container>
+  );
+}
+
+const Container = styled.View`
+  flex: 1;
+  background-color: ${theme.colors.white};
+`;
+
+const HeaderPlaceholder = styled.View`
+  height: 50px;
+`;
+
+const TabContainer = styled.View`
+  flex-direction: row;
+  border-bottom-width: 1px;
+  border-bottom-color: ${theme.colors.grey.neutral200};
+`;
+
+const TabButton = styled.TouchableOpacity<{ active: boolean }>`
+  flex: 1;
+  padding-vertical: 12px;
+  align-items: center;
+  border-bottom-width: 2px;
+  border-bottom-color: ${({ active }) =>
+    active ? theme.colors.text.textPrimary : "transparent"};
+`;
+
+const TabText = styled.Text<{ active: boolean }>`
+  font-family: ${({ active }) =>
+    active
+      ? theme.typography.fontFamily.semiBold
+      : theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${({ active }) =>
+    active ? theme.colors.text.textPrimary : theme.colors.text.textTertiary};
+`;
+
+const StyledPagerView = styled(PagerView)`
+  flex: 1;
+`;
+
+const PageContainer = styled.View`
+  flex: 1;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const EmptyContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  padding-top: 100px;
+`;
+
+const EmptyText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${theme.colors.text.textTertiary};
+`;

--- a/app/(tabs)/story/storyAdd.tsx
+++ b/app/(tabs)/story/storyAdd.tsx
@@ -114,7 +114,7 @@ export default function StoryAdd() {
 
         <StoryAddContainer>
           <TitleWrapper>
-            <Title>Add Stroy</Title>
+            <Title>Add Story</Title>
           </TitleWrapper>
 
           <MapButtonWrapper onPress={handleMapButton}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react-native-heroicons": "^4.0.0",
         "react-native-image-picker": "^8.2.1",
         "react-native-maps": "^1.26.20",
+        "react-native-pager-view": "6.9.1",
         "react-native-popover-view": "^6.1.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -16083,6 +16084,16 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-pager-view": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.9.1.tgz",
+      "integrity": "sha512-uUT0MMMbNtoSbxe9pRvdJJKEi9snjuJ3fXlZhG8F2vVMOBJVt/AFtqMPUHu9yMflmqOr08PewKzj9EPl/Yj+Gw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-popover-view": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native-heroicons": "^4.0.0",
     "react-native-image-picker": "^8.2.1",
     "react-native-maps": "^1.26.20",
+    "react-native-pager-view": "6.9.1",
     "react-native-popover-view": "^6.1.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/src/api/story/getMyStoryApi.ts
+++ b/src/api/story/getMyStoryApi.ts
@@ -1,0 +1,50 @@
+import { BaseResponse } from "@/types/auth";
+import { GetLikedStoriesRequest, GetMyStoriesRequest, MyStoryListResponse, ToggleLikeResponse } from "@/types/myStory";
+
+import API_ENDPOINTS from "@/constants/endpoints";
+
+import api from "../axios";
+
+export const getMyStories = async (
+    param: GetMyStoriesRequest
+): Promise<MyStoryListResponse> => {
+    try {
+        const response = await api.get<BaseResponse<MyStoryListResponse>>(
+            API_ENDPOINTS.STORY.MY_STORIES,
+            { params: param }
+        );
+        return response.data.data;
+    } catch (error) {
+        throw error;
+    }
+};
+
+export const toggleStoryLike = async (
+    storyId: number
+): Promise<ToggleLikeResponse> => {
+    try {
+
+        const response = await api.post<BaseResponse<ToggleLikeResponse>>(
+            API_ENDPOINTS.STORY.TOGGLE_LIKE(storyId)
+        );
+
+        return response.data.data;
+    } catch (error) {
+        console.error("toggleStoryLike 에러:", error);
+        throw error;
+    }
+};
+
+export const getLikedStories = async (
+    param: GetLikedStoriesRequest
+): Promise<MyStoryListResponse> => {
+    try {
+        const response = await api.get<BaseResponse<MyStoryListResponse>>(
+            API_ENDPOINTS.STORY.LIKED_STORIES,
+            { params: param }
+        );
+        return response.data.data;
+    } catch (error) {
+        throw error;
+    }
+};

--- a/src/api/story/getStoryAddApi.ts
+++ b/src/api/story/getStoryAddApi.ts
@@ -11,17 +11,10 @@ export const getcreateStory = async (
   images?: string[]
 ) => {
   try {
-    const createTextRes = await api.post<BaseResponse<CreateStoryResponse>>(
-      `${API_ENDPOINTS.STORY.CREATE}`,
-      param
-    );
-
-    const storyData = createTextRes.data.data;
-    const storyId = storyData.storyId;
+    const formData = new FormData();
+    formData.append("body", JSON.stringify(param));
 
     if (images && images.length > 0) {
-      const formData = new FormData();
-
       images.forEach((imageUri, index) => {
         formData.append("images", {
           uri: imageUri,
@@ -29,18 +22,19 @@ export const getcreateStory = async (
           name: `image_${index}.jpg`,
         } as any);
       });
-
-      await api.post<BaseResponse<void>>(
-        `/api/user/story/image/${storyId}`,
-        formData,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
-          },
-        }
-      );
     }
-    return createTextRes.data;
+
+    const response = await api.post<BaseResponse<CreateStoryResponse>>(
+      `${API_ENDPOINTS.STORY.CREATE}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+
+    return response.data;
   } catch (error) {
     throw error;
   }

--- a/src/components/story/Heart.tsx
+++ b/src/components/story/Heart.tsx
@@ -1,29 +1,23 @@
-import { useState } from "react";
-
 import { Octicons } from "@expo/vector-icons";
 import styled from "styled-components/native";
 
 import { theme } from "@/styles/theme";
 
-interface HearProps {
-  heartCount?: number;
+interface HeartProps {
+  storyId: number;
+  likeCount: number;
+  isLiked: boolean;
+  onToggle: (storyId: number) => void;
+  disabled?: boolean;
 }
 
-const Heart: React.FC<HearProps> = ({ heartCount }) => {
-  const [isHeart, setIsHeart] = useState(false);
-
-  const handleIcon = () => {
-    if (!isHeart) {
-      setIsHeart(true);
-    } else {
-      setIsHeart(false);
-    }
-  };
-
+const Heart: React.FC<HeartProps> = ({ storyId, likeCount, isLiked, onToggle, disabled }) => {
   return (
-    <StyledHeart onPress={handleIcon}>
-      <HeartIcon onPress={handleIcon}>
-        {isHeart ? (
+    <StyledHeart onPress={() => {
+      onToggle(storyId)}
+      } disabled={disabled}>
+      <HeartIcon>
+        {isLiked ? (
           <Octicons
             name="heart-fill"
             size={20}
@@ -37,7 +31,7 @@ const Heart: React.FC<HearProps> = ({ heartCount }) => {
           />
         )}
       </HeartIcon>
-      <HeartCount>{heartCount}</HeartCount>
+      <HeartCount>{likeCount}</HeartCount>
     </StyledHeart>
   );
 };
@@ -48,11 +42,11 @@ const StyledHeart = styled.Pressable`
   gap: 5px;
 `;
 
-const HeartIcon = styled.Pressable``;
+const HeartIcon = styled.View``;
 
 const HeartCount = styled.Text`
   font-family: ${theme.typography.fontFamily.regular};
-  font-size: ${theme.typography.fontSize.sm};
+  font-size: ${theme.typography.fontSize.sm}px;
   color: ${theme.colors.text.textSecondary};
 `;
 

--- a/src/components/story/StoryCard.tsx
+++ b/src/components/story/StoryCard.tsx
@@ -5,6 +5,8 @@ import { View } from "react-native";
 import { ChevronRight, MoreHorizontal } from "lucide-react-native";
 import styled from "styled-components/native";
 
+import { useMyStory } from "@/hooks/story/useMyStory";
+
 import { theme } from "@/styles/theme";
 import { DEFAULT_IMAGE_URL } from "@/assets/images/defaultImage";
 
@@ -14,6 +16,7 @@ import Heart from "./Heart";
 import MoreMenuButton from "./MoreMenuButton";
 
 interface StoryCardProps {
+  storyId: number;
   profileUrl?: string;
   userNickName?: string;
   stroySpotName?: string;
@@ -21,11 +24,13 @@ interface StoryCardProps {
   content?: string;
   createdAt?: string;
   likeCount?: number;
+  isLiked?: boolean;
   imageUrls?: string[];
   authorId?: number;
 }
 
 const StoryCard: React.FC<StoryCardProps> = ({
+  storyId,
   profileUrl,
   userNickName,
   stroySpotName,
@@ -33,6 +38,7 @@ const StoryCard: React.FC<StoryCardProps> = ({
   content,
   createdAt,
   likeCount,
+  isLiked,
   imageUrls,
   authorId,
 }) => {
@@ -41,6 +47,8 @@ const StoryCard: React.FC<StoryCardProps> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [showButton, setShowButton] = useState(false);
   const [isMenuVisible, setIsMenuVisible] = useState(false);
+  const toggleLike = useMyStory((s) => s.toggleLike);
+  const isLoading = useMyStory((s) => s.isLoading);
 
   const moreButtonRef = useRef<View>(null);
 
@@ -89,7 +97,7 @@ const StoryCard: React.FC<StoryCardProps> = ({
       <StyledContainer>
         <ImageContainer>
           <ProfileImage
-            source={{ uri: profileUrl ?? DEFAULT_IMAGE_URL }}
+            source={{ uri: profileUrl || DEFAULT_IMAGE_URL }}
           ></ProfileImage>
         </ImageContainer>
         <TextContainer>
@@ -165,7 +173,13 @@ const StoryCard: React.FC<StoryCardProps> = ({
           </ContentWrapper>
           <PostInfoWrapper>
             <HeartIconSection>
-              <Heart heartCount={likeCount} />
+              <Heart 
+                storyId={storyId}
+                likeCount={likeCount ?? 0}
+                isLiked={!!isLiked}
+                onToggle={toggleLike}
+                disabled={isLoading} 
+              />
             </HeartIconSection>
             <CreatedAtSection>{createdAt}</CreatedAtSection>
           </PostInfoWrapper>

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -23,6 +23,9 @@ export const API_ENDPOINTS = {
     STORY_LIST_IN_MAP: "/api/story/map/rectangle",
     SPOT_LIST_IN_MAP: "/api/story/spot/map/rectangle",
     EDIT: (storyId: number) => `/api/user/story/${storyId}`,
+    MY_STORIES: "/api/user/story/my",
+    TOGGLE_LIKE: (storyId: number) => `/api/user/story/${storyId}/like`,
+    LIKED_STORIES: "/api/user/story/liked",
   },
 
   SIGHT: {

--- a/src/hooks/story/useLikedStory.ts
+++ b/src/hooks/story/useLikedStory.ts
@@ -1,0 +1,75 @@
+import { create } from "zustand";
+
+import { GetLikedStoriesRequest, MyStoryItem } from "@/types/myStory";
+
+import { getLikedStories } from "@/api/story/getMyStoryApi";
+
+type LikedStoryState = {
+    likedStories: MyStoryItem[];
+    lastStoryLikeId: number | null;
+    hasNext: boolean;
+    isLoading: boolean;
+
+    fetchLikedStories: (isRefresh?: boolean) => Promise<void>;
+    refreshLikedStories: () => void;
+    syncLikeState: (storyId: number, isLiked: boolean, likeCount: number) => void;
+};
+
+export const useLikedStory = create<LikedStoryState>((set, get) => ({
+    likedStories: [],
+    lastStoryLikeId: null,
+    hasNext: false,
+    isLoading: false,
+
+    fetchLikedStories: async (isRefresh = false) => {
+        const { isLoading, lastStoryLikeId } = get();
+        if (isLoading) return;
+
+        set({ isLoading: true });
+        try {
+            const param: GetLikedStoriesRequest = {
+                size: 10,
+                lastStoryLikeId: isRefresh ? undefined : lastStoryLikeId ?? undefined,
+            };
+
+            const response = await getLikedStories(param);
+
+            const formattedStories = response.stories.map((story) => ({
+                ...story,
+                createdAt: formatDateArray(story.createdAt),
+                isLiked: true,
+            }));
+
+            set((s) => ({
+                likedStories: isRefresh ? formattedStories : [...s.likedStories, ...formattedStories],
+                lastStoryLikeId: response.lastStoryId,
+                hasNext: response.hasNext,
+            }));
+        } catch (error) {
+            console.error("좋아요한 글 조회 실패:", error);
+        } finally {
+            set({ isLoading: false });
+        }
+    },
+
+    refreshLikedStories: () => {
+        set({ lastStoryLikeId: null });
+        get().fetchLikedStories(true);
+    },
+
+    syncLikeState: (storyId: number, isLiked: boolean, likeCount: number) => {
+        set((s) => ({
+            likedStories: s.likedStories.map((st) =>
+                st.storyId === storyId ? { ...st, isLiked, likeCount } : st
+            ),
+        }));
+    },
+}));
+
+function formatDateArray(dateArray: number[] | string | undefined): string {
+    if (typeof dateArray === "string") return dateArray;
+    if (!dateArray || !Array.isArray(dateArray)) return "";
+
+    const [year, month, day, hour, minute] = dateArray;
+    return `${year}.${String(month).padStart(2, "0")}.${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}

--- a/src/hooks/story/useMyStory.ts
+++ b/src/hooks/story/useMyStory.ts
@@ -1,0 +1,115 @@
+import { create } from "zustand";
+
+import { GetMyStoriesRequest, MyStoryItem, ToggleLikeResponse } from "@/types/myStory";
+
+import { getMyStories, toggleStoryLike } from "@/api/story/getMyStoryApi";
+
+import { useLikedStory } from "./useLikedStory";
+
+type MyStoryState = {
+    myStories: MyStoryItem[];
+    lastStoryId: number | null;
+    hasNext: boolean;
+    isLoading: boolean;
+
+    fetchMyStories: (isRefresh?: boolean) => Promise<void>;
+    toggleLike: (storyId: number) => Promise<void>;
+};
+
+export const useMyStory = create<MyStoryState>((set, get) => ({
+    myStories: [],
+    lastStoryId: null,
+    hasNext: false,
+    isLoading: false,
+
+    fetchMyStories: async (isRefresh = false) => {
+        const { isLoading, lastStoryId } = get();
+        if (isLoading) return;
+
+        set({ isLoading: true });
+        try {
+            const param: GetMyStoriesRequest = {
+                size: 10,
+                lastStoryId: isRefresh ? undefined : lastStoryId ?? undefined,
+            };
+
+            const response = await getMyStories(param);
+
+            const incoming: MyStoryItem[] = response.stories.map((story: MyStoryItem) => ({
+                ...story,
+                createdAt: formatDateArray(story.createdAt),
+                isLiked: story.isLiked ?? false,
+            }));
+
+            set((s) => {
+                const merged = incoming.map((p) => {
+                    const local = s.myStories.find((x) => x.storyId === p.storyId);
+                    if (!local) return p;
+
+                    return {
+                        ...p,
+                        isLiked: typeof local.isLiked === "boolean" ? local.isLiked : p.isLiked,
+                        likeCount: typeof local.likeCount === "number" ? local.likeCount : p.likeCount,
+                    };
+                });
+
+                return {
+                    myStories: isRefresh ? merged : [...s.myStories, ...merged],
+                    lastStoryId: response.lastStoryId,
+                    hasNext: response.hasNext,
+                };
+            });
+        } catch (e) {
+            console.error("내 이야기 조회 실패:", e);
+        } finally {
+            set({ isLoading: false });
+        }
+    },
+    toggleLike: async (storyId: number) => {
+        const current = get().myStories.find((s) => s.storyId === storyId);
+        if (!current) return;
+
+        const prevIsLiked = !!current.isLiked;
+        const prevCount = current.likeCount ?? 0;
+
+        const nextIsLiked = !prevIsLiked;
+        const nextCount = prevIsLiked ? Math.max(0, prevCount - 1) : prevCount + 1;
+
+        set((s) => ({
+            myStories: s.myStories.map((st) =>
+                st.storyId === storyId ? { ...st, isLiked: nextIsLiked, likeCount: nextCount } : st
+            ),
+        }));
+
+        useLikedStory.getState().syncLikeState(storyId, nextIsLiked, nextCount);
+
+        try {
+            const res = (await toggleStoryLike(storyId)) as ToggleLikeResponse;
+
+            set((s) => ({
+                myStories: s.myStories.map((st) =>
+                    st.storyId === storyId
+                        ? { ...st, isLiked: res.isLiked, likeCount: res.likeCount }
+                        : st
+                ),
+            }));
+            useLikedStory.getState().syncLikeState(storyId, res.isLiked, res.likeCount);
+        } catch (e) {
+            set((s) => ({
+                myStories: s.myStories.map((st) =>
+                    st.storyId === storyId ? { ...st, isLiked: prevIsLiked, likeCount: prevCount } : st
+                ),
+            }));
+            useLikedStory.getState().syncLikeState(storyId, prevIsLiked, prevCount);
+            console.error("좋아요 토글 실패:", e);
+        }
+    },
+}));
+
+function formatDateArray(dateArray: number[] | string | undefined): string {
+    if (typeof dateArray === "string") return dateArray;
+    if (!dateArray || !Array.isArray(dateArray)) return "";
+
+    const [year, month, day, hour, minute] = dateArray;
+    return `${year}.${String(month).padStart(2, "0")}.${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}

--- a/src/types/myStory.ts
+++ b/src/types/myStory.ts
@@ -1,0 +1,40 @@
+export interface MyStoryItem {
+    storyId: number;
+    storyAuthor?: {
+        storyAuthorId?: number;
+        nickname?: string;
+        profileUrl?: string;
+    };
+    title?: string;
+    content?: string;
+    storyConcept?: "TIP" | "EXPERIENCE" | "CULTURE" | "HISTORY" | "ETC";
+    imageUrls?: string[];
+    likeCount?: number;
+    storySpotId?: number;
+    latitude?: number;
+    longitude?: number;
+    createdAt?: number[] | string;
+    updatedAt?: number[] | string;
+    isLiked?: boolean;
+}
+
+export interface MyStoryListResponse {
+    stories: MyStoryItem[];
+    lastStoryId: number | null;
+    hasNext: boolean;
+}
+
+export interface GetMyStoriesRequest {
+    lastStoryId?: number;
+    size?: number;
+}
+
+export interface ToggleLikeResponse {
+    isLiked: boolean;
+    likeCount: number;
+}
+
+export interface GetLikedStoriesRequest {
+    lastStoryLikeId?: number;
+    size?: number;
+}

--- a/src/types/storySpot.ts
+++ b/src/types/storySpot.ts
@@ -69,10 +69,10 @@ export interface GetStoryRequest {
       page?: number;
       size?: number;
       sort?:
-        | "createdAt,desc"
-        | "createdAt,asc"
-        | "likeCount,desc"
-        | "likeCount,asc";
+      | "createdAt,desc"
+      | "createdAt,asc"
+      | "likeCount,desc"
+      | "likeCount,asc";
     };
   };
 }


### PR DESCRIPTION
## 🧩 구현/변경 사항

- 마이페이지 - 내 이야기
- 페이저뷰 의존성 설치
- 내 이야기/내가 좋아요한 글 API 연결
- 좋아요, 스토리 카드 컴포넌트 수정
- 내 이야기/내가 좋아요한 글 페이지 개발
- 이야기 등록 API 변경사항 수정

---

## 🧪 테스트 결과
<img width="300" alt="test (5)" src="https://github.com/user-attachments/assets/7a929432-6d5c-4bcf-9418-babfe50c1f9a" />
<img width="300"alt="test (4)" src="https://github.com/user-attachments/assets/7bc97242-f2db-4cb8-be4e-b2d0927ebfe1" />
<img width="300" alt="test (3)" src="https://github.com/user-attachments/assets/db02ed0a-d588-44ae-90b8-1bbf45bd5514" />


---

## BREAKING CHANGE (옵션)

- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고

- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)

---

## 💬 리뷰 받고 싶은 부분 (옵션)

