### PR TITLE
[#51] 마이페이지 - 지난 여행

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,7 +5,6 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
 
 import { Ionicons } from "@expo/vector-icons";
-import { useLocalSearchParams } from "expo-router";
 import styled from "styled-components/native";
 
 import CustomBottomSheet from "@/components/bottomSheet/CustomBottomSheet";
@@ -17,6 +16,7 @@ import Map from "@/components/map/Map";
 import SightDetailCard from "@/components/sight/SightDetailCard";
 
 import { useCurationDetail } from "@/hooks/sight/useCurationDetail";
+import { useSightNavigation } from "@/hooks/sight/useSightNavigation";
 import { useLocation } from "@/hooks/useLocation";
 import { useSightMap } from "@/hooks/useSightMap";
 
@@ -25,10 +25,7 @@ import { SightInfo } from "@/types/sight";
 
 import { theme } from "@/styles/theme";
 
-import { getSightDetail } from "@/api/sight/getSight";
-import { useHeaderButtonStore } from "@/store/useHeaderButtonStore";
 import { RouteCartItem, useRouteCartStore } from "@/store/useRouteCartStore";
-import { useSightStore } from "@/store/useSightStore";
 
 export default function Index() {
   const bottomSheetRef = useRef<any>(null);
@@ -41,7 +38,6 @@ export default function Index() {
 
   const [searchText, setSearchText] = useState("");
   const [showResults, setShowResults] = useState(false);
-  const { sightId } = useLocalSearchParams<{ sightId?: string }>();
 
   const {
     sights,
@@ -71,43 +67,16 @@ export default function Index() {
     fetchCurations();
   }, [fetchCurations]);
 
+  const { navigateSightId, navigateToSight } = useSightNavigation({
+    mapRef,
+    location,
+  });
+
   useEffect(() => {
-    if (sightId && location) {
-      const fetchAndMove = async () => {
-        try {
-          const detail = await getSightDetail({
-            id: sightId,
-            longitude: location.longitude,
-            latitude: location.latitude,
-          });
-
-          // 지도 이동
-          mapRef.current?.moveToLocation({
-            latitude: detail.latitude,
-            longitude: detail.longitude,
-            latitudeDelta: 0.01,
-            longitudeDelta: 0.01,
-          });
-
-          // 선택된 관광지 설정
-          const sight: SightInfo = {
-            id: sightId,
-            title: detail.title,
-            longitude: detail.longitude,
-            latitude: detail.latitude,
-            geoHash: "",
-          };
-          
-          useSightStore.getState().selectSight(sight);
-          useSightStore.getState().setSightDetail(detail);
-        } catch (error) {
-          console.error("관광지 조회 실패:", error);
-        }
-      };
-
-      fetchAndMove();
+    if (navigateSightId && location) {
+      navigateToSight(navigateSightId);
     }
-  }, [sightId, location.latitude, location.longitude]);
+  }, [navigateSightId, location.latitude, location.longitude, navigateToSight]);
 
   const handleSearch = useCallback(async () => {
     if (!searchText.trim()) return;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
 
 import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams } from "expo-router";
 import styled from "styled-components/native";
 
 import CustomBottomSheet from "@/components/bottomSheet/CustomBottomSheet";
@@ -24,8 +25,10 @@ import { SightInfo } from "@/types/sight";
 
 import { theme } from "@/styles/theme";
 
+import { getSightDetail } from "@/api/sight/getSight";
 import { useHeaderButtonStore } from "@/store/useHeaderButtonStore";
 import { RouteCartItem, useRouteCartStore } from "@/store/useRouteCartStore";
+import { useSightStore } from "@/store/useSightStore";
 
 export default function Index() {
   const bottomSheetRef = useRef<any>(null);
@@ -38,6 +41,7 @@ export default function Index() {
 
   const [searchText, setSearchText] = useState("");
   const [showResults, setShowResults] = useState(false);
+  const { sightId } = useLocalSearchParams<{ sightId?: string }>();
 
   const {
     sights,
@@ -66,6 +70,44 @@ export default function Index() {
   useEffect(() => {
     fetchCurations();
   }, [fetchCurations]);
+
+  useEffect(() => {
+    if (sightId && location) {
+      const fetchAndMove = async () => {
+        try {
+          const detail = await getSightDetail({
+            id: sightId,
+            longitude: location.longitude,
+            latitude: location.latitude,
+          });
+
+          // 지도 이동
+          mapRef.current?.moveToLocation({
+            latitude: detail.latitude,
+            longitude: detail.longitude,
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+          });
+
+          // 선택된 관광지 설정
+          const sight: SightInfo = {
+            id: sightId,
+            title: detail.title,
+            longitude: detail.longitude,
+            latitude: detail.latitude,
+            geoHash: "",
+          };
+          
+          useSightStore.getState().selectSight(sight);
+          useSightStore.getState().setSightDetail(detail);
+        } catch (error) {
+          console.error("관광지 조회 실패:", error);
+        }
+      };
+
+      fetchAndMove();
+    }
+  }, [sightId, location.latitude, location.longitude]);
 
   const handleSearch = useCallback(async () => {
     if (!searchText.trim()) return;

--- a/app/(tabs)/myPage/_layout.tsx
+++ b/app/(tabs)/myPage/_layout.tsx
@@ -23,6 +23,8 @@ export default function MyPageLayout() {
       />
 
       <Stack.Screen name="editProfile" options={{ title: "회원정보수정" }} />
+      <Stack.Screen name="pastTrip" options={{ title: "지난 여행" }} />
+      <Stack.Screen name="pastTripDetail" options={{ title: "지난 여행 상세" }} />
     </Stack>
   );
 }

--- a/app/(tabs)/myPage/index.tsx
+++ b/app/(tabs)/myPage/index.tsx
@@ -111,7 +111,7 @@ function LoggedInView({
           <BookmarkIcon width={24} height={24} color={theme.colors.white} />
           <TabLabel>북마크</TabLabel>
         </TabButton>
-        <TabButton onPress={() => console.log("지난 여행")}>
+        <TabButton onPress={() => router.push("/myPage/pastTrip" as any)}>
           <LastTripIcon width={24} height={24} color={theme.colors.white} />
           <TabLabel>지난 여행</TabLabel>
         </TabButton>

--- a/app/(tabs)/myPage/pastTrip.tsx
+++ b/app/(tabs)/myPage/pastTrip.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { ActivityIndicator, Alert, FlatList, Modal } from "react-native";
+
+import { useRouter } from "expo-router";
+import { Pencil, Trash2 } from "lucide-react-native";
+import styled from "styled-components/native";
+
+import { useCompletedRoute } from "@/hooks/route/useCompletedRoute";
+
+import { CompletedRouteSummary } from "@/types/completedRoute";
+
+import { theme } from "@/styles/theme";
+
+export default function PastTrip() {
+  const router = useRouter();
+  const {
+    routes,
+    hasNext,
+    isLoading,
+    fetchRoutes,
+    modifyRouteName,
+    deleteRoute,
+  } = useCompletedRoute();
+
+  const [editModalVisible, setEditModalVisible] = useState(false);
+  const [editingRoute, setEditingRoute] = useState<CompletedRouteSummary | null>(null);
+  const [editName, setEditName] = useState("");
+
+  useEffect(() => {
+    fetchRoutes(true);
+  }, []);
+
+  const handleItemPress = (routeId: number) => {
+    router.push({
+      pathname: "/myPage/pastTripDetail",
+      params: { routeId },
+    });
+  };
+
+  const handleEditPress = (route: CompletedRouteSummary) => {
+    setEditingRoute(route);
+    setEditName(route.name);
+    setEditModalVisible(true);
+  };
+
+  const handleEditSubmit = async () => {
+    if (!editingRoute || !editName.trim()) return;
+
+    try {
+      await modifyRouteName(editingRoute.routeId, editName.trim());
+      setEditModalVisible(false);
+      setEditingRoute(null);
+      setEditName("");
+    } catch (error) {
+      Alert.alert("오류", "이름 수정에 실패했습니다.");
+    }
+  };
+
+  const handleDeletePress = (route: CompletedRouteSummary) => {
+    Alert.alert(
+      "여행 삭제",
+      `"${route.name}"기록을 정말 삭제하시겠습니까?\n삭제된 데이터는 복구할 수 없습니다.`,
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "삭제",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await deleteRoute(route.routeId);
+            } catch (error) {
+              Alert.alert("오류", "삭제에 실패했습니다.");
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const renderItem = useCallback(
+    ({ item }: { item: CompletedRouteSummary }) => (
+      <RouteItem onPress={() => handleItemPress(item.routeId)}>
+        <RouteInfo>
+          <RouteName>{item.name}</RouteName>
+          <RouteDate>{item.completedAt}</RouteDate>
+        </RouteInfo>
+        <ButtonGroup>
+          <ActionButton onPress={() => handleEditPress(item)}>
+            <Pencil size={18} color={theme.colors.text.textSecondary} />
+          </ActionButton>
+          <ActionButton onPress={() => handleDeletePress(item)}>
+            <Trash2 size={18} color={theme.colors.text.textSecondary} />
+          </ActionButton>
+        </ButtonGroup>
+      </RouteItem>
+    ),
+    []
+  );
+
+  return (
+    <Container>
+      <Header>
+        <HeaderTitle>지난 여행</HeaderTitle>
+      </Header>
+
+      <FlatList
+        data={routes}
+        keyExtractor={(item) => item.routeId.toString()}
+        renderItem={renderItem}
+        refreshing={isLoading && routes.length === 0}
+        onRefresh={() => fetchRoutes(true)}
+        onEndReached={() => {
+          if (hasNext && !isLoading) {
+            fetchRoutes(false);
+          }
+        }}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={
+          isLoading && routes.length > 0 ? (
+            <ActivityIndicator style={{ padding: 20 }} />
+          ) : null
+        }
+        ListEmptyComponent={
+          !isLoading ? (
+            <EmptyContainer>
+              <EmptyText>지난 여행이 없습니다</EmptyText>
+            </EmptyContainer>
+          ) : null
+        }
+        contentContainerStyle={{ flexGrow: 1 }}
+      />
+
+      <Modal
+        visible={editModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setEditModalVisible(false)}
+      >
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>여행 이름 수정</ModalTitle>
+            <ModalInput
+              value={editName}
+              onChangeText={setEditName}
+              placeholder="여행 이름 입력"
+              placeholderTextColor={theme.colors.text.textTertiary}
+              autoFocus
+            />
+            <ModalButtonGroup>
+              <ModalButton onPress={() => setEditModalVisible(false)}>
+                <ModalButtonText>취소</ModalButtonText>
+              </ModalButton>
+              <ModalButton onPress={handleEditSubmit} primary>
+                <ModalButtonText primary>확인</ModalButtonText>
+              </ModalButton>
+            </ModalButtonGroup>
+          </ModalContent>
+        </ModalOverlay>
+      </Modal>
+    </Container>
+  );
+}
+
+const Container = styled.View`
+  flex: 1;
+  background-color: ${theme.colors.white};
+`;
+
+const Header = styled.View`
+  height: 50px;
+  justify-content: center;
+  align-items: center;
+  border-bottom-width: 1px;
+  border-bottom-color: ${theme.colors.grey.neutral200};
+`;
+
+const HeaderTitle = styled.Text`
+  font-family: ${theme.typography.fontFamily.semiBold};
+  font-size: ${theme.typography.fontSize.lg}px;
+  color: ${theme.colors.text.textPrimary};
+`;
+
+const RouteItem = styled.TouchableOpacity`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom-width: 1px;
+  border-bottom-color: ${theme.colors.grey.neutral200};
+`;
+
+const RouteInfo = styled.View`
+  flex: 1;
+`;
+
+const RouteName = styled.Text`
+  font-family: ${theme.typography.fontFamily.medium};
+  font-size: ${theme.typography.fontSize.md}px;
+  color: ${theme.colors.text.textPrimary};
+  margin-bottom: 4px;
+`;
+
+const RouteDate = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.xs}px;
+  color: ${theme.colors.text.textTertiary};
+`;
+
+const ButtonGroup = styled.View`
+  flex-direction: row;
+  gap: 8px;
+`;
+
+const ActionButton = styled.TouchableOpacity`
+  padding: 8px 12px;
+`;
+
+const ActionButtonText = styled.Text`
+  font-family: ${theme.typography.fontFamily.medium};
+  font-size: ${theme.typography.fontSize.xs}px;
+  color: ${theme.colors.text.textSecondary};
+`;
+
+const EmptyContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+const EmptyText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${theme.colors.text.textTertiary};
+`;
+
+const ModalOverlay = styled.View`
+  flex: 1;
+  background-color: ${theme.colors.background.modalBackground};
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+`;
+
+const ModalContent = styled.View`
+  width: 100%;
+  background-color: ${theme.colors.white};
+  border-radius: ${theme.borderRadius.md}px;
+  padding: 20px;
+`;
+
+const ModalTitle = styled.Text`
+  font-family: ${theme.typography.fontFamily.semiBold};
+  font-size: ${theme.typography.fontSize.md}px;
+  color: ${theme.colors.text.textPrimary};
+  margin-bottom: 16px;
+  text-align: center;
+`;
+
+const ModalInput = styled.TextInput`
+  background-color: ${theme.colors.background.background50};
+  border-radius: ${theme.borderRadius.md}px;
+  padding: 12px 16px;
+  font-size: ${theme.typography.fontSize.md}px;
+  color: ${theme.colors.text.textPrimary};
+  margin-bottom: 16px;
+`;
+
+const ModalButtonGroup = styled.View`
+  flex-direction: row;
+  gap: 12px;
+`;
+
+const ModalButton = styled.TouchableOpacity<{ primary?: boolean }>`
+  flex: 1;
+  padding: 12px;
+  border-radius: ${theme.borderRadius.md}px;
+  background-color: ${(props) =>
+    props.primary ? theme.colors.main.primary : theme.colors.grey.neutral200};
+  align-items: center;
+`;
+
+const ModalButtonText = styled.Text<{ primary?: boolean }>`
+  font-family: ${theme.typography.fontFamily.medium};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${(props) =>
+    props.primary ? theme.colors.white : theme.colors.text.textPrimary};
+`;

--- a/app/(tabs)/myPage/pastTripDetail.tsx
+++ b/app/(tabs)/myPage/pastTripDetail.tsx
@@ -1,0 +1,152 @@
+import { useEffect } from "react";
+
+import { ActivityIndicator, FlatList } from "react-native";
+
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { ChevronLeft } from "lucide-react-native";
+import styled from "styled-components/native";
+
+import SightCard from "@/components/common/SightCard";
+
+import { useCompletedRoute } from "@/hooks/route/useCompletedRoute";
+
+import { CompletedRouteItem } from "@/types/completedRoute";
+
+import { theme } from "@/styles/theme";
+
+export default function PastTripDetail() {
+  const router = useRouter();
+  const { routeId } = useLocalSearchParams<{ routeId: string }>();
+  const {
+    selectedRoute,
+    selectedRouteItems,
+    isDetailLoading,
+    fetchRouteDetail,
+    clearDetail,
+  } = useCompletedRoute();
+
+  const handleCardPress = (item: CompletedRouteItem) => {
+    if (item.itemType === "SIGHT") {
+      router.push({
+        pathname: "/(tabs)",
+        params: { sightId: item.itemId },
+      } as any);
+    } else {
+      router.push({
+        pathname: "/(tabs)/story",
+        params: { storySpotId: item.itemId },
+      } as any);
+    }
+  };
+
+  useEffect(() => {
+    if (routeId) {
+      fetchRouteDetail(Number(routeId));
+    }
+
+    return () => {
+      clearDetail();
+    };
+  }, [routeId]);
+
+  const renderItem = ({ item }: { item: CompletedRouteItem }) => (
+    <CardWrapper>
+      <SightCard
+        image={item.itemImageUrl}
+        sightName={item.itemName}
+        sightTheme={item.itemType === "SIGHT" ? "관광지" : "이야기 스팟"}
+        iconStyle="DETAIL"
+        iconColor={theme.colors.text.textSecondary}
+        onCardPress={() => handleCardPress(item)}
+      />
+    </CardWrapper>
+  );
+
+  if (isDetailLoading) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator size="large" color={theme.colors.main.primary} />
+      </LoadingContainer>
+    );
+  }
+
+  return (
+    <Container>
+      <Header>
+        <BackButton onPress={() => router.back()}>
+          <ChevronLeft size={24} color={theme.colors.text.textPrimary} />
+        </BackButton>
+        <HeaderTitle numberOfLines={2} adjustsFontSizeToFit={false}>{selectedRoute?.name || "여행 상세"}</HeaderTitle>
+        <HeaderSpacer />
+      </Header>
+
+      <FlatList
+        data={selectedRouteItems}
+        keyExtractor={(item, index) => `${item.itemType}-${item.itemId}-${index}`}
+        renderItem={renderItem}
+        contentContainerStyle={{ padding: 20, gap: 12 }}
+        ListEmptyComponent={
+          <EmptyContainer>
+            <EmptyText>방문한 장소가 없습니다</EmptyText>
+          </EmptyContainer>
+        }
+      />
+    </Container>
+  );
+}
+
+const Container = styled.View`
+  flex: 1;
+  background-color: ${theme.colors.white};
+`;
+
+const LoadingContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.white};
+`;
+
+const Header = styled.View`
+  height: 50px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-horizontal: 15px;
+  border-bottom-width: 1px;
+  border-bottom-color: ${theme.colors.grey.neutral200};
+`;
+
+const BackButton = styled.TouchableOpacity`
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  align-items: flex-start;
+`;
+
+const HeaderTitle = styled.Text`
+  font-family: ${theme.typography.fontFamily.semiBold};
+  font-size: ${theme.typography.fontSize.lg}px;
+  color: ${theme.colors.text.textPrimary};
+  flex: 1;
+  text-align: center;
+`;
+
+const HeaderSpacer = styled.View`
+  width: 40px;
+`;
+
+const CardWrapper = styled.View`
+  align-items: center;
+`;
+
+const EmptyContainer = styled.View`
+  padding: 40px;
+  align-items: center;
+`;
+
+const EmptyText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${theme.colors.text.textTertiary};
+`;

--- a/app/(tabs)/myPage/pastTripDetail.tsx
+++ b/app/(tabs)/myPage/pastTripDetail.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { ActivityIndicator, FlatList } from "react-native";
 
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft, MessageSquare } from "lucide-react-native";
+import { ChevronLeft, MessageSquareHeart } from "lucide-react-native";
 import styled from "styled-components/native";
 
 import SightCard from "@/components/common/SightCard";
@@ -66,7 +66,7 @@ export default function PastTripDetail() {
 
     return (
       <StorySpotItem onPress={() => handleCardPress(item)}>
-        <MessageSquare size={20} color={theme.colors.text.textSecondary} />
+        <MessageSquareHeart size={20} color={theme.colors.text.textSecondary} />
         <StorySpotText>{item.itemName}</StorySpotText>
       </StorySpotItem>
     );

--- a/app/(tabs)/myPage/pastTripDetail.tsx
+++ b/app/(tabs)/myPage/pastTripDetail.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { ActivityIndicator, FlatList } from "react-native";
 
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { ChevronLeft } from "lucide-react-native";
+import { ChevronLeft, MessageSquare } from "lucide-react-native";
 import styled from "styled-components/native";
 
 import SightCard from "@/components/common/SightCard";
@@ -13,6 +13,9 @@ import { useCompletedRoute } from "@/hooks/route/useCompletedRoute";
 import { CompletedRouteItem } from "@/types/completedRoute";
 
 import { theme } from "@/styles/theme";
+
+import { useStoryStore } from "@/store/story/useStoryStore";
+import { useSightStore } from "@/store/useSightStore";
 
 export default function PastTripDetail() {
   const router = useRouter();
@@ -27,15 +30,11 @@ export default function PastTripDetail() {
 
   const handleCardPress = (item: CompletedRouteItem) => {
     if (item.itemType === "SIGHT") {
-      router.push({
-        pathname: "/(tabs)",
-        params: { sightId: item.itemId },
-      } as any);
+      useSightStore.getState().setNavigateSightId(item.itemId);
+      router.push("/(tabs)");
     } else {
-      router.push({
-        pathname: "/(tabs)/story",
-        params: { storySpotId: item.itemId },
-      } as any);
+      useStoryStore.getState().setNavigateStorySpotId(Number(item.itemId));
+      router.push("/(tabs)/story");
     }
   };
 
@@ -49,18 +48,29 @@ export default function PastTripDetail() {
     };
   }, [routeId]);
 
-  const renderItem = ({ item }: { item: CompletedRouteItem }) => (
-    <CardWrapper>
-      <SightCard
-        image={item.itemImageUrl}
-        sightName={item.itemName}
-        sightTheme={item.itemType === "SIGHT" ? "관광지" : "이야기 스팟"}
-        iconStyle="DETAIL"
-        iconColor={theme.colors.text.textSecondary}
-        onCardPress={() => handleCardPress(item)}
-      />
-    </CardWrapper>
-  );
+  const renderItem = ({ item }: { item: CompletedRouteItem }) => {
+    if (item.itemType === "SIGHT") {
+      return (
+        <CardWrapper>
+          <SightCard
+            image={item.itemImageUrl}
+            sightName={item.itemName}
+            sightTheme="관광지"
+            iconStyle="DETAIL"
+            iconColor={theme.colors.text.textSecondary}
+            onCardPress={() => handleCardPress(item)}
+          />
+        </CardWrapper>
+      );
+    }
+
+    return (
+      <StorySpotItem onPress={() => handleCardPress(item)}>
+        <MessageSquare size={20} color={theme.colors.text.textSecondary} />
+        <StorySpotText>{item.itemName}</StorySpotText>
+      </StorySpotItem>
+    );
+  };
 
   if (isDetailLoading) {
     return (
@@ -149,4 +159,17 @@ const EmptyText = styled.Text`
   font-family: ${theme.typography.fontFamily.regular};
   font-size: ${theme.typography.fontSize.sm}px;
   color: ${theme.colors.text.textTertiary};
+`;
+
+const StorySpotItem = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+  padding: 12px 16px;
+  gap: 10px;
+`;
+
+const StorySpotText = styled.Text`
+  font-family: ${theme.typography.fontFamily.regular};
+  font-size: ${theme.typography.fontSize.sm}px;
+  color: ${theme.colors.text.textPrimary};
 `;

--- a/app/(tabs)/story/index.tsx
+++ b/app/(tabs)/story/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 
 import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -29,6 +29,22 @@ export default function Index() {
   } = useStorySpotMap();
 
   const { spotLocationInMap } = useStoryStore();
+
+  const navigateStorySpotId = useStoryStore((state) => state.navigateStorySpotId);
+
+  useEffect(() => {
+    if (!navigateStorySpotId) return;
+
+    const targetSpot = spotLocationInMap?.find(
+      (spot) => spot.storySpotId === navigateStorySpotId
+    );
+
+    if (targetSpot) {
+      handleStoryMarkerPress(targetSpot);
+    }
+
+    useStoryStore.getState().clearNavigateStorySpotId();
+  }, [navigateStorySpotId, spotLocationInMap]);
 
   return (
     <Container>

--- a/app/(tabs)/story/index.tsx
+++ b/app/(tabs)/story/index.tsx
@@ -12,7 +12,9 @@ import MainStoryHeader from "@/components/story/MainStoryHeader";
 import { StoryAddButton } from "@/components/story/StoryAddButton";
 import StorySpotHeader from "@/components/story/StorySpotHeader";
 
+import { useStoryNavigation } from "@/hooks/story/useStoryNavigation";
 import { useStorySpotMap } from "@/hooks/story/useStorySpotMap";
+import { useLocation } from "@/hooks/useLocation";
 
 import { useStoryStore } from "@/store/story/useStoryStore";
 
@@ -23,6 +25,7 @@ export default function Index() {
   const {
     mapRef,
     selectedMarker,
+    setSelectedMarker,
     handleMapPress,
     handleRegionChange,
     handleStoryMarkerPress,
@@ -30,21 +33,19 @@ export default function Index() {
 
   const { spotLocationInMap } = useStoryStore();
 
-  const navigateStorySpotId = useStoryStore((state) => state.navigateStorySpotId);
+  const { location } = useLocation();
+
+  const { navigateStorySpotId, navigateToStorySpot } = useStoryNavigation({
+    mapRef,
+    location,
+    setSelectedMarker,
+  });
 
   useEffect(() => {
-    if (!navigateStorySpotId) return;
-
-    const targetSpot = spotLocationInMap?.find(
-      (spot) => spot.storySpotId === navigateStorySpotId
-    );
-
-    if (targetSpot) {
-      handleStoryMarkerPress(targetSpot);
+    if (navigateStorySpotId && location) {
+      navigateToStorySpot(navigateStorySpotId);
     }
-
-    useStoryStore.getState().clearNavigateStorySpotId();
-  }, [navigateStorySpotId, spotLocationInMap]);
+  }, [navigateStorySpotId, location.latitude, location.longitude, navigateToStorySpot]);
 
   return (
     <Container>

--- a/src/api/route/completedRouteApi.ts
+++ b/src/api/route/completedRouteApi.ts
@@ -1,0 +1,55 @@
+import { BaseResponse } from "@/types/auth";
+import {
+    CompletedRouteDetailResponse,
+    CompletedRouteListRequest,
+    CompletedRouteListResponse,
+    CompletedRouteSummary,
+    ModifyCompletedRouteRequest,
+} from "@/types/completedRoute";
+
+import API_ENDPOINTS from "@/constants/endpoints";
+
+import api from "@/api/axios";
+
+// 완료된 경로 리스트 조회
+export const getCompletedRoutes = async (
+    params?: CompletedRouteListRequest
+): Promise<CompletedRouteListResponse> => {
+    const response = await api.get<BaseResponse<CompletedRouteListResponse>>(
+        API_ENDPOINTS.ROUTE.COMPLETED_LIST,
+        {
+            params: {
+                page: params?.page ?? 0,
+                size: params?.size ?? 10,
+            },
+        }
+    );
+    return response.data.data;
+};
+
+// 완료된 경로 상세 조회
+export const getCompletedRouteDetail = async (
+    routeId: number
+): Promise<CompletedRouteDetailResponse> => {
+    const response = await api.get<BaseResponse<CompletedRouteDetailResponse>>(
+        API_ENDPOINTS.ROUTE.COMPLETED_DETAIL(routeId)
+    );
+    return response.data.data;
+};
+
+// 완료된 경로 이름 수정
+export const modifyCompletedRouteName = async (
+    routeId: number,
+    data: ModifyCompletedRouteRequest
+): Promise<CompletedRouteSummary> => {
+    const response = await api.put<BaseResponse<CompletedRouteSummary>>(
+        API_ENDPOINTS.ROUTE.COMPLETED_MODIFY(routeId),
+        data
+    );
+    return response.data.data;
+};
+
+// 완료된 경로 삭제
+export const deleteCompletedRoute = async (routeId: number): Promise<void> => {
+    await api.delete(API_ENDPOINTS.ROUTE.COMPLETED_MODIFY(routeId));
+};

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -43,6 +43,9 @@ export const API_ENDPOINTS = {
   ROUTE: {
     CREATE_IN_PROGRESS_ROUTE: "/api/user/route/in-progress",
     COMPLETE_ROUTE: (routeId: number) => `/api/user/route/${routeId}/complete`,
+    COMPLETED_LIST: "/api/user/route/completed",
+    COMPLETED_DETAIL: (routeId: number) => `/api/user/route/completed/detail/${routeId}`,
+    COMPLETED_MODIFY: (routeId: number) => `/api/user/route/completed/${routeId}`,
   },
   MEMBER: {
     GET_PROFILE: "/api/user/member/profile",

--- a/src/hooks/route/useCompletedRoute.ts
+++ b/src/hooks/route/useCompletedRoute.ts
@@ -1,0 +1,122 @@
+import { create } from "zustand";
+
+import {
+    CompletedRouteItem,
+    CompletedRouteSummary,
+} from "@/types/completedRoute";
+
+import {
+    deleteCompletedRoute,
+    getCompletedRouteDetail,
+    getCompletedRoutes,
+    modifyCompletedRouteName,
+} from "@/api/route/completedRouteApi";
+
+type CompletedRouteState = {
+    routes: CompletedRouteSummary[];
+    hasNext: boolean;
+    currentPage: number;
+    isLoading: boolean;
+
+    selectedRoute: CompletedRouteSummary | null;
+    selectedRouteItems: CompletedRouteItem[];
+    isDetailLoading: boolean;
+
+    fetchRoutes: (isRefresh?: boolean) => Promise<void>;
+    fetchRouteDetail: (routeId: number) => Promise<void>;
+    modifyRouteName: (routeId: number, name: string) => Promise<void>;
+    deleteRoute: (routeId: number) => Promise<void>;
+    clearDetail: () => void;
+};
+
+export const useCompletedRoute = create<CompletedRouteState>((set, get) => ({
+    routes: [],
+    hasNext: false,
+    currentPage: 0,
+    isLoading: false,
+
+    selectedRoute: null,
+    selectedRouteItems: [],
+    isDetailLoading: false,
+
+    fetchRoutes: async (isRefresh = false) => {
+        const { isLoading, currentPage, hasNext } = get();
+
+        if (isLoading) return;
+        if (!isRefresh && !hasNext && currentPage > 0) return;
+
+        set({ isLoading: true });
+
+        try {
+            const page = isRefresh ? 0 : currentPage;
+            const response = await getCompletedRoutes({ page, size: 10 });
+
+            set((state) => ({
+                routes: isRefresh
+                    ? response.routes
+                    : [...state.routes, ...response.routes],
+                hasNext: response.hasNext,
+                currentPage: page + 1,
+            }));
+        } catch (error) {
+            console.error("완료된 경로 조회 실패:", error);
+        } finally {
+            set({ isLoading: false });
+        }
+    },
+
+    fetchRouteDetail: async (routeId: number) => {
+        set({ isDetailLoading: true });
+
+        try {
+            const response = await getCompletedRouteDetail(routeId);
+
+            set({
+                selectedRoute: response.route,
+                selectedRouteItems: response.items,
+            });
+        } catch (error) {
+            console.error("경로 상세 조회 실패:", error);
+        } finally {
+            set({ isDetailLoading: false });
+        }
+    },
+
+    modifyRouteName: async (routeId: number, name: string) => {
+        try {
+            const updated = await modifyCompletedRouteName(routeId, { name });
+
+            set((state) => ({
+                routes: state.routes.map((route) =>
+                    route.routeId === routeId ? { ...route, name: updated.name } : route
+                ),
+                selectedRoute: state.selectedRoute?.routeId === routeId
+                    ? { ...state.selectedRoute, name: updated.name }
+                    : state.selectedRoute,
+            }));
+        } catch (error) {
+            console.error("경로 이름 수정 실패:", error);
+            throw error;
+        }
+    },
+
+    deleteRoute: async (routeId: number) => {
+        try {
+            await deleteCompletedRoute(routeId);
+
+            set((state) => ({
+                routes: state.routes.filter((route) => route.routeId !== routeId),
+            }));
+        } catch (error) {
+            console.error("경로 삭제 실패:", error);
+            throw error;
+        }
+    },
+
+    clearDetail: () => {
+        set({
+            selectedRoute: null,
+            selectedRouteItems: [],
+        });
+    },
+}));

--- a/src/hooks/sight/useSightNavigation.ts
+++ b/src/hooks/sight/useSightNavigation.ts
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+
+import { MapRef } from "@/types/map";
+import { SightInfo } from "@/types/sight";
+
+import { getSightDetail } from "@/api/sight/getSight";
+import { useSightStore } from "@/store/useSightStore";
+
+interface UseSightNavigationParams {
+    mapRef: React.RefObject<MapRef | null>;
+    location: {
+        latitude: number;
+        longitude: number;
+    };
+}
+
+export const useSightNavigation = ({ mapRef, location }: UseSightNavigationParams) => {
+    const navigateSightId = useSightStore((state) => state.navigateSightId);
+
+    const navigateToSight = useCallback(async (sightId: string) => {
+        try {
+            useSightStore.getState().setDetailLoading(true);
+
+            const detail = await getSightDetail({
+                id: sightId,
+                longitude: location.longitude,
+                latitude: location.latitude,
+            });
+
+            const sight: SightInfo = {
+                id: sightId,
+                title: detail.title,
+                longitude: detail.longitude,
+                latitude: detail.latitude,
+                geoHash: "",
+            };
+
+            // 지도 이동
+            mapRef.current?.moveToLocation({
+                latitude: detail.latitude,
+                longitude: detail.longitude,
+                latitudeDelta: 0.01,
+                longitudeDelta: 0.01,
+            });
+
+            useSightStore.getState().selectSight(sight);
+            useSightStore.getState().setSightDetail(detail);
+            useSightStore.getState().clearNavigateSightId();
+        } catch (error) {
+            console.error("관광지 조회 실패:", error);
+            useSightStore.getState().clearNavigateSightId();
+        } finally {
+            useSightStore.getState().setDetailLoading(false);
+        }
+    }, [location.latitude, location.longitude, mapRef]);
+
+    return {
+        navigateSightId,
+        navigateToSight,
+    };
+};

--- a/src/hooks/story/useStoryNavigation.ts
+++ b/src/hooks/story/useStoryNavigation.ts
@@ -1,0 +1,71 @@
+import { useCallback } from "react";
+
+import { MapRef } from "@/types/map";
+
+import { useStoryStore } from "@/store/story/useStoryStore";
+
+interface UseStoryNavigationParams {
+    mapRef: React.RefObject<MapRef | null>;
+    location: {
+        latitude: number;
+        longitude: number;
+    };
+    setSelectedMarker: (id: number | undefined) => void;
+}
+
+export const useStoryNavigation = ({ mapRef, location, setSelectedMarker }: UseStoryNavigationParams) => {
+    const navigateStorySpotId = useStoryStore((state) => state.navigateStorySpotId);
+    const { setStoryInfo, setStorySpotBriefInfo } = useStoryStore();
+
+    const navigateToStorySpot = useCallback(async (storySpotId: number) => {
+        try {
+            const storyRequest = {
+                storySpotId,
+                query: {
+                    query: {
+                        longitude: location.longitude,
+                        latitude: location.latitude,
+                        locale: "KO" as const,
+                        page: 0,
+                        size: 1000,
+                        sort: "createdAt,desc" as const,
+                    },
+                },
+            };
+
+            // 스토어 업데이트 (바텀시트 데이터)
+            const response = await setStoryInfo(storyRequest);
+
+            const briefSpotInfo = response?.briefSpotInfo;
+
+            if (briefSpotInfo?.latitude && briefSpotInfo?.longitude) {
+                // 스토어 업데이트
+                setStorySpotBriefInfo({
+                    latitude: briefSpotInfo.latitude,
+                    longitude: briefSpotInfo.longitude,
+                });
+
+                // 지도 이동
+                mapRef.current?.moveToLocation({
+                    latitude: briefSpotInfo.latitude,
+                    longitude: briefSpotInfo.longitude,
+                    latitudeDelta: 0.01,
+                    longitudeDelta: 0.01,
+                });
+
+                // 바텀시트 전환
+                setSelectedMarker(storySpotId);
+            }
+
+            useStoryStore.getState().clearNavigateStorySpotId();
+        } catch (error) {
+            console.error("이야기 스팟 조회 실패:", error);
+            useStoryStore.getState().clearNavigateStorySpotId();
+        }
+    }, [location.latitude, location.longitude, mapRef, setSelectedMarker, setStoryInfo, setStorySpotBriefInfo]);
+
+    return {
+        navigateStorySpotId,
+        navigateToStorySpot,
+    };
+};

--- a/src/hooks/story/useStorySpotMap.ts
+++ b/src/hooks/story/useStorySpotMap.ts
@@ -133,6 +133,7 @@ export const useStorySpotMap = () => {
   return {
     mapRef,
     selectedMarker: selectedMarkerId,
+    setSelectedMarker: setSelectedMarkerId,
     handleMapPress,
     handleRegionChange,
     handleStoryMarkerPress,

--- a/src/store/story/useStoryStore.ts
+++ b/src/store/story/useStoryStore.ts
@@ -39,6 +39,10 @@ interface StoryStore {
   searchedStoryInfo?: storySpots[];
   spotLocationInMap?: MapSpotInfoItem[];
 
+  navigateStorySpotId: number | null;
+  setNavigateStorySpotId: (storySpotId: number) => void;
+  clearNavigateStorySpotId: () => void;
+
   setSearchStory: (
     param: GetSearchStoryRequest
   ) => Promise<SearchStoryInfoResponse | undefined>;
@@ -200,6 +204,12 @@ export const useStoryStore = create<StoryStore>((set, get) => ({
       return undefined;
     }
   },
+
+  navigateStorySpotId: null,
+
+  setNavigateStorySpotId: (storySpotId: number) => set({ navigateStorySpotId: storySpotId }),
+
+  clearNavigateStorySpotId: () => set({ navigateStorySpotId: null }),
 }));
 
 function formatDateArray(dateArray: number[] | string | undefined): string {

--- a/src/store/useSightStore.ts
+++ b/src/store/useSightStore.ts
@@ -10,6 +10,8 @@ interface SightState {
   isDetailLoading: boolean;
   error: string | null;
 
+  navigateSightId: string | null;
+
   setSights: (sights: SightInfo[]) => void;
   selectSight: (sight: SightInfo | null) => void;
   setSightDetail: (detail: SightDetailInfo | null) => void;
@@ -18,6 +20,9 @@ interface SightState {
   setError: (error: string | null) => void;
   clearSelection: () => void;
   reset: () => void;
+
+  setNavigateSightId: (sightId: string) => void;
+  clearNavigateSightId: () => void;
 }
 
 const initialState = {
@@ -27,6 +32,7 @@ const initialState = {
   isLoading: false,
   isDetailLoading: false,
   error: null,
+  navigateSightId: null,
 };
 
 export const useSightStore = create<SightState>((set) => ({
@@ -55,4 +61,8 @@ export const useSightStore = create<SightState>((set) => ({
     }),
 
   reset: () => set(initialState),
+
+  setNavigateSightId: (sightId) => set({ navigateSightId: sightId }),
+
+  clearNavigateSightId: () => set({ navigateSightId: null }),
 }));

--- a/src/types/completedRoute.ts
+++ b/src/types/completedRoute.ts
@@ -1,0 +1,39 @@
+import { RouteItemType } from "./route";
+
+// 완료된 경로 요약 정보
+export interface CompletedRouteSummary {
+    routeId: number;
+    name: string;
+    completedAt: string; // yyyy.MM.dd 형식
+}
+
+// 완료된 경로 리스트 응답
+export interface CompletedRouteListResponse {
+    routes: CompletedRouteSummary[];
+    hasNext: boolean;
+}
+
+// 완료된 경로 상세 아이템
+export interface CompletedRouteItem {
+    itemType: RouteItemType;
+    itemId: string;
+    itemName: string;
+    itemImageUrl: string;
+}
+
+// 완료된 경로 상세 응답
+export interface CompletedRouteDetailResponse {
+    route: CompletedRouteSummary;
+    items: CompletedRouteItem[];
+}
+
+// 경로 이름 수정 요청
+export interface ModifyCompletedRouteRequest {
+    name: string;
+}
+
+// 페이징 요청 파라미터
+export interface CompletedRouteListRequest {
+    page?: number;
+    size?: number;
+}


### PR DESCRIPTION
## 🧩 구현/변경 사항

- 마이페이지 - 지난 여행
- 여행 종료 시 완료된 경로에 한해서 사용자에게 지난 여행경로 보여주기 위한 페이지 제작
- 지난 여행 리스트 페이지
- 여행을 눌렀을때 상세 페이지로 이동하여 설정한 경로에 대한 관광지 확인 가능
- 상세 페이지에서 특정 관광지 클릭시 메인 화면으로 이동해 해당 관광지의 상세 페이지로 이동할 수 있도록 설정
- 지난 여행 제목 수정
- 지난 여행 삭제

---

## 사용자 시나리오(UML)
<img width="350" alt="지난여행 (2)" src="https://github.com/user-attachments/assets/cbc8dcc8-2d9a-4137-bf35-6332e9c15c3e" />

<img width="350" alt="지난여행 (3)" src="https://github.com/user-attachments/assets/1236ac95-5d93-4716-bc3a-69782eef5dc9" />

- 메인 화면의 관광지 상세 페이지에서 경로 추가 후 생성된 경로의 여행 종료시 "완료" 처리가 성공적으로 처리되면 마이페이지 - 지난 여행에서 확인 가능

<img width="350" alt="지난여행 (4)" src="https://github.com/user-attachments/assets/96995e07-cf0b-4211-9911-09c2736f46fe" />
<img width="350" alt="지난여행 (5)" src="https://github.com/user-attachments/assets/be547c82-7d32-4c89-a637-00df15b0127a" />

- 지난 여행 제목 수정

<img width="350" alt="지난여행 (7)" src="https://github.com/user-attachments/assets/67400cd4-2124-4383-8787-d6fa8a2da9c2" />
<img width="350" alt="지난여행 (8)" src="https://github.com/user-attachments/assets/7f22d940-12c3-4a22-8dd8-5caa01275a08" />

- 여행을 눌렀을때 상세 페이지로 이동하여 설정한 경로에 대한 관광지 확인 가능
- 상세 페이지에서 특정 관광지 클릭시 메인 화면으로 이동해 해당 관광지의 상세 페이지로 이동할 수 있도록 설정

<img width="350" alt="지난여행 (9)" src="https://github.com/user-attachments/assets/170bad49-2636-42cb-bee5-ccfd6f3e8d93" />
<img width="350" alt="지난여행 (1)" src="https://github.com/user-attachments/assets/0f8c67c8-9a8d-446c-95a6-90715381e2f4" />

- 지난 여행 삭제
---

## 참고

- 페이지 상단의 헤더는 피그마 기준으로 제작되었으나 추후에 헤더 관련 컴포넌트 완성 시 변경하겠습니다
- 지난 여행 상세 페이지의 제목같은 경우는 제목이 길면 다음 줄로 넘어가도록 설정했습니다.
- 이야기 스팟은 현재 경로 탭에서 개발이 미완성이라서 관광지만 노출되고 있습니다.
- expo-router의 useLocalSearchParams, useEffect를 사용해서 지난 여행에서 메인 화면 탭으로 넘어가 관광지 상세 페이지를 띄우는 작업을 진행했습니다

---

## 💬 리뷰 받고 싶은 부분 (옵션)

- 수정 및 삭제 시 모달창 관련 의견 주시면 감사하겠습니다
- 현재 수정은 따로 모달창을 만들었고 삭제는 Alert로 관리되고 있습니다.
